### PR TITLE
Update Margin generation to use hipscat `MarginCatalog`

### DIFF
--- a/sprints/2024/02_08/Margin generation.ipynb
+++ b/sprints/2024/02_08/Margin generation.ipynb
@@ -16,31 +16,89 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "39b8fa75",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:53:09.781157Z",
+     "start_time": "2024-01-31T21:52:49.428496Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset\n",
+    "from hipscat.catalog import MarginCatalog\n",
     "from hipscat.io import file_io, paths\n",
     "\n",
     "margin_5arcs = \"/data3/epyc/data3/hipscat/test_catalogs/ztf_dr14_5arcs\"\n",
     "margin_10arcs = \"/data3/epyc/data3/hipscat/catalogs/ztf_dr14_10arcs\"\n",
     "\n",
-    "small_margin = HealpixDataset.read_from_hipscat(margin_5arcs)\n",
-    "big_margin = HealpixDataset.read_from_hipscat(margin_10arcs)"
+    "small_margin = MarginCatalog.read_from_hipscat(margin_5arcs)\n",
+    "big_margin = MarginCatalog.read_from_hipscat(margin_10arcs)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "5.0"
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "small_margin.catalog_info.margin_threshold"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:54:24.127412Z",
+     "start_time": "2024-01-31T21:54:24.119746Z"
+    }
+   },
+   "id": "dbefd4b6a5368758"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "10"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "big_margin.catalog_info.margin_threshold"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:54:29.716732Z",
+     "start_time": "2024-01-31T21:54:29.705495Z"
+    }
+   },
+   "id": "f4199b03e8bcc565"
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "id": "e13bbc81",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:53:18.700736Z",
+     "start_time": "2024-01-31T21:53:18.696540Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "2553574"
-      ]
+      "text/plain": "2553574"
      },
      "execution_count": 2,
      "metadata": {},
@@ -55,13 +113,16 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "0bcd193c",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:53:20.193237Z",
+     "start_time": "2024-01-31T21:53:20.186074Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "5220930"
-      ]
+      "text/plain": "5220930"
      },
      "execution_count": 3,
      "metadata": {},
@@ -88,13 +149,16 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "19f044cf",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:53:22.332516Z",
+     "start_time": "2024-01-31T21:53:22.328989Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "2.044557941144451"
-      ]
+      "text/plain": "2.044557941144451"
      },
      "execution_count": 4,
      "metadata": {},
@@ -117,7 +181,12 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "4493430a",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:53:41.913050Z",
+     "start_time": "2024-01-31T21:53:41.911985Z"
+    }
+   },
    "outputs": [],
    "source": [
     "assert big_margin.partition_info.get_healpix_pixels() == small_margin.partition_info.get_healpix_pixels()"
@@ -135,17 +204,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 6,
    "id": "a79acb4b",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:53:47.271834Z",
+     "start_time": "2024-01-31T21:53:47.270343Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "Order: 3, Pixel: 178"
-      ]
+      "text/plain": "Order: 3, Pixel: 178"
      },
-     "execution_count": 10,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -157,17 +229,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "f0febd17",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:54:45.663662Z",
+     "start_time": "2024-01-31T21:54:45.622443Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "2.8181818181818183"
-      ]
+      "text/plain": "2.8181818181818183"
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,79 +259,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "ac2c92ca",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:54:47.011221Z",
+     "start_time": "2024-01-31T21:54:46.993408Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>margin_Norder</th>\n",
-       "      <th>margin_Npix</th>\n",
-       "      <th>size</th>\n",
-       "      <th>proportion</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>3</td>\n",
-       "      <td>167</td>\n",
-       "      <td>89</td>\n",
-       "      <td>23.116883</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>3</td>\n",
-       "      <td>176</td>\n",
-       "      <td>120</td>\n",
-       "      <td>31.168831</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>179</td>\n",
-       "      <td>66</td>\n",
-       "      <td>17.142857</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>184</td>\n",
-       "      <td>110</td>\n",
-       "      <td>28.571429</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   margin_Norder  margin_Npix  size  proportion\n",
-       "0              3          167    89   23.116883\n",
-       "1              3          176   120   31.168831\n",
-       "2              3          179    66   17.142857\n",
-       "3              3          184   110   28.571429"
-      ]
+      "text/plain": "   margin_Norder  margin_Npix  size  proportion\n0              3          167    89   23.116883\n1              3          176   120   31.168831\n2              3          179    66   17.142857\n3              3          184   110   28.571429",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>margin_Norder</th>\n      <th>margin_Npix</th>\n      <th>size</th>\n      <th>proportion</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>3</td>\n      <td>167</td>\n      <td>89</td>\n      <td>23.116883</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>3</td>\n      <td>176</td>\n      <td>120</td>\n      <td>31.168831</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>179</td>\n      <td>66</td>\n      <td>17.142857</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>184</td>\n      <td>110</td>\n      <td>28.571429</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -269,79 +286,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "9976ddb8",
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-01-31T21:54:49.831395Z",
+     "start_time": "2024-01-31T21:54:49.809927Z"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>margin_Norder</th>\n",
-       "      <th>margin_Npix</th>\n",
-       "      <th>size</th>\n",
-       "      <th>proportion</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>3</td>\n",
-       "      <td>167</td>\n",
-       "      <td>255</td>\n",
-       "      <td>23.502304</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>3</td>\n",
-       "      <td>176</td>\n",
-       "      <td>312</td>\n",
-       "      <td>28.755760</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>179</td>\n",
-       "      <td>278</td>\n",
-       "      <td>25.622120</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>184</td>\n",
-       "      <td>240</td>\n",
-       "      <td>22.119816</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   margin_Norder  margin_Npix  size  proportion\n",
-       "0              3          167   255   23.502304\n",
-       "1              3          176   312   28.755760\n",
-       "2              3          179   278   25.622120\n",
-       "3              3          184   240   22.119816"
-      ]
+      "text/plain": "   margin_Norder  margin_Npix  size  proportion\n0              3          167   255   23.502304\n1              3          176   312   28.755760\n2              3          179   278   25.622120\n3              3          184   240   22.119816",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>margin_Norder</th>\n      <th>margin_Npix</th>\n      <th>size</th>\n      <th>proportion</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>3</td>\n      <td>167</td>\n      <td>255</td>\n      <td>23.502304</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>3</td>\n      <td>176</td>\n      <td>312</td>\n      <td>28.755760</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>3</td>\n      <td>179</td>\n      <td>278</td>\n      <td>25.622120</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>3</td>\n      <td>184</td>\n      <td>240</td>\n      <td>22.119816</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -351,13 +310,23 @@
     "stats[\"proportion\"] = stats[\"size\"]/len(big_margin_data)*100\n",
     "stats"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   },
+   "id": "6b7e9636c8896973"
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Melissa LSDB",
+   "name": "sean_lsdb",
    "language": "python",
-   "name": "mmd11_lsdb"
+   "display_name": "Sean lsdb"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Notebook now uses the `MarginCatalog` class to load and represent the margin catalogs. Added a few cells to look at the new metadata, but the `MarginCatalog` acts basically the same as other catalogs so it's mostly unchanged. Still, nice to see it doesn't break!